### PR TITLE
feat: add security api call

### DIFF
--- a/src/config/vipUsers.ts
+++ b/src/config/vipUsers.ts
@@ -1,3 +1,4 @@
+import { axiosInstance } from '@/infrastructure/api/axiosInstance';
 import axios from 'axios';
 
 /**
@@ -40,8 +41,8 @@ export const isVipUser = async (): Promise<boolean> => {
       return false;
     }
 
-    const response = await axios.post(
-      `${import.meta.env.VITE_API_URL}/auth/is-vip`,
+    const response = await axiosInstance.post(
+      `/auth/is-vip`,
       {},
       {
         headers: {

--- a/src/data/datasource/Remote.datasource.ts
+++ b/src/data/datasource/Remote.datasource.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { getCsrfToken } from '@/utils/Csrf';
 import axios, {
   AxiosError,
   AxiosInstance,
@@ -44,7 +45,18 @@ export class RemoteDataSource {
     this.api = axios.create({
       baseURL: baseURL,
       headers: headers,
+      withCredentials: true,
     });
+
+    this.api.interceptors.request.use(
+      (config) => {
+        config.headers['X-CSRF-Token'] = getCsrfToken();
+        return config;
+      },
+      (error) => {
+        return Promise.reject(error);
+      },
+    );
   }
 
   public setBaseURL(baseURL: string): void {

--- a/src/infrastructure/api/axiosInstance.ts
+++ b/src/infrastructure/api/axiosInstance.ts
@@ -1,3 +1,4 @@
+import { getCsrfToken } from '@/utils/Csrf';
 import axios from 'axios';
 
 export const axiosInstance = axios.create({
@@ -5,14 +6,36 @@ export const axiosInstance = axios.create({
   headers: {
     'x-api-key': import.meta.env.VITE_API_KEY,
   },
+  withCredentials: true,
 });
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    config.headers['X-CSRF-Token'] = getCsrfToken();
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
 
 export const axiosCoupon = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
   headers: {
     'x-api-key': import.meta.env.VITE_API_KEY,
   },
+  withCredentials: true,
 });
+
+axiosCoupon.interceptors.request.use(
+  (config) => {
+    config.headers['X-CSRF-Token'] = getCsrfToken();
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
 
 export const setAuthToken = (token: string | null) => {
   if (token) {

--- a/src/utils/Csrf.ts
+++ b/src/utils/Csrf.ts
@@ -1,0 +1,13 @@
+export function getCsrfToken() {
+  const name = '_csrf=';
+  const decodedCookie = decodeURIComponent(document.cookie);
+  const ca = decodedCookie.split(';');
+
+  for (let i = 0; i < ca.length; i++) {
+    const c = ca[i].trim();
+    if (c.indexOf(name) === 0) {
+      return c.substring(name.length);
+    }
+  }
+  return '';
+}

--- a/src/view/screens/Checkout/DataForm/useDataForm.ts
+++ b/src/view/screens/Checkout/DataForm/useDataForm.ts
@@ -4,7 +4,7 @@ import {
   isPaymentMethodInMaintenance,
 } from '@/config/paymentMaintenance';
 import { generateVipPixCode, isVipUser } from '@/config/vipUsers';
-
+import { axiosInstance } from '@/infrastructure/api/axiosInstance';
 import { useAuth } from '@/view/hooks/useAuth';
 import { useUserLevel } from '@/view/hooks/useUserLevel';
 import axios from 'axios';
@@ -419,8 +419,8 @@ Cupom: ${cupom}`;
 
     try {
       // Todos os métodos salvam no backend antes de redirecionar
-      const response = await axios.post(
-        `${import.meta.env.VITE_API_URL}/deposit`,
+      const response = await axiosInstance.post(
+        `/deposit`,
         {
           valorBRL: valorToSend,
           valorBTC: parseFloat(cryptoAmount),
@@ -440,7 +440,6 @@ Cupom: ${cupom}`;
             Authorization: userObj?.acessToken
               ? `Bearer ${userObj.acessToken}`
               : '',
-            'x-api-key': import.meta.env.VITE_API_KEY,
           },
         },
       );
@@ -639,12 +638,6 @@ Cupom: ${cupom}`;
 
     try {
       setIsLoading(true);
-      const axiosInstance = axios.create({
-        baseURL: import.meta.env.VITE_API_URL,
-        headers: {
-          'x-api-key': import.meta.env.VITE_API_KEY,
-        },
-      });
 
       const response = await axiosInstance.post(`coupons/is-valid`, {
         code: cupom.trim().toUpperCase(),

--- a/src/view/screens/Checkout/usePaymentStatusPolling.ts
+++ b/src/view/screens/Checkout/usePaymentStatusPolling.ts
@@ -1,6 +1,6 @@
+import { axiosInstance } from '@/infrastructure/api/axiosInstance';
 import { ROUTES } from '@/view/routes/Routes';
 import { useCurrentLang } from '@/view/utils/useCurrentLang';
-import axios from 'axios';
 import { t } from 'i18next';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -40,13 +40,8 @@ export const usePaymentStatusPolling = () => {
     setIsLoadingPayment(true);
 
     try {
-      const response = await axios.get(
-        `${import.meta.env.VITE_API_URL}/deposit-status?transactionId=${transaction}`,
-        {
-          headers: {
-            'x-api-key': import.meta.env.VITE_API_KEY,
-          },
-        },
+      const response = await axiosInstance.get(
+        `/deposit-status?transactionId=${transaction}`,
       );
       const status = response.data.status;
 

--- a/src/view/screens/Support/support.tsx
+++ b/src/view/screens/Support/support.tsx
@@ -1,9 +1,9 @@
+import { axiosInstance } from '@/infrastructure/api/axiosInstance';
 import { Loader } from '@/view/components/Loader';
 import { AlfredLogo } from '@/view/components/Logo/AlfredLogo';
 import { PageBackground } from '@/view/components/PageBackground';
 import { useScaleFactor } from '@/view/hooks/useScaleFactor';
 import { useWindowSize } from '@/view/utils/useWindowSize';
-import axios from 'axios';
 import classNames from 'classnames';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -35,10 +35,7 @@ export function Support() {
     setIsLoading(true);
 
     try {
-      const response = await axios.post(
-        `${import.meta.env.VITE_API_URL}/support`,
-        data,
-      );
+      const response = await axiosInstance.post(`/support`, data);
 
       if (response.status === 200 || response.status === 201) {
         toast.success(t('support.successMessage'), {


### PR DESCRIPTION
## Descrição da Pull Request

Esta PR realiza importantes refatorações e melhorias no front-end, com foco em padronização das chamadas HTTP e reforço na segurança com o tratamento de CSRF. As principais alterações são:

### ✅ Refatorações

- Substituição do uso direto do `axios` pelo `axiosInstance` nas seguintes partes da aplicação:
  - `usePaymentStatusPolling`
  - `vipUsers`
  - `useDataForm`
  - `Support`

Esta mudança garante centralização de configurações, como interceptadores e cabeçalhos padrão, além de facilitar futuras manutenções.

### ✅ Novas funcionalidades

- **CSRF Token**
  - Criada a função `getCsrfToken` para recuperar o token CSRF armazenado nos cookies.
  - Adicionado tratamento automático do CSRF token dentro das instâncias de `axios` e no `RemoteDataSource`, garantindo que todas as requisições sejam protegidas contra ataques de Cross-Site Request Forgery.

---

## 🎯 Motivação

- Centralizar e padronizar a configuração de chamadas HTTP na aplicação.
- Fortalecer a segurança das requisições com a proteção contra CSRF.
- Facilitar a manutenção e evolução do código.

---

## 📋 Checklist

- [x] `axios` substituído por `axiosInstance` nos módulos mencionados.
- [x] Função de recuperação de CSRF token implementada.
- [x] CSRF token integrado ao `axiosInstance` e ao `RemoteDataSource`.
- [x] Garantia de segurança nas requisições via token CSRF.

---

## 📝 Notas adicionais

- É importante garantir que o token CSRF está sendo devidamente setado nos cookies pelo backend.
- As mudanças são retrocompatíveis, mas recomenda-se testar fluxos críticos que dependem de autenticação e formulários.

