### PR TITLE
Add address confirmation

### DIFF
--- a/src/domain/locales/en/translation.json
+++ b/src/domain/locales/en/translation.json
@@ -211,7 +211,7 @@
     "invalidColdWalletErrorLiquid": "Invalid Liquid wallet address. Please verify the address is correct and try again.",
     "invalidColdWalletErrorOnchain": "Invalid Onchain wallet address. Use a valid Bitcoin address (bc1... or 1... or 3...).",
     "invalidColdWalletErrorLightning": "Invalid Lightning wallet address. Use only a LNURL or a valid Lightning email.",
-    "invalidLnurl": "Invalid LNURL. Please check the address and try again.",
+    "invalidLnurl": "LNURL not supported, please use the Lightning email format.",
     "invalidLnurlResponse": "Invalid response from LNURL server.",
     "fixedAmountLnurlNotSupported": "Fixed amount LNURLs are not supported. Please use a LNURL that allows custom amounts.",
     "lightningInvoiceNotSupported": "Lightning invoices (bolt11) are no longer supported. Use only LNURL or Lightning email.",

--- a/src/domain/locales/en/translation.json
+++ b/src/domain/locales/en/translation.json
@@ -326,6 +326,10 @@
       "expected_amount": "Expected Amount (BRL)",
       "expected_amount_crypto": "Expected Amount (Crypto)"
     },
+    "wallet_confirmation": {
+      "title": "Address Confirmation",
+      "checkbox_label": "I confirm that the address is correct:"
+    },
     "buttons": {
       "cancel": "Cancel",
       "confirm": "Confirm"

--- a/src/domain/locales/es/translation.json
+++ b/src/domain/locales/es/translation.json
@@ -327,6 +327,10 @@
       "expected_amount": "Valor Esperado (BRL)",
       "expected_amount_crypto": "Valor Esperado (Cripto)"
     },
+    "wallet_confirmation": {
+      "title": "Confirmación de Dirección",
+      "checkbox_label": "Confirmo que la dirección es correcta:"
+    },
     "buttons": {
       "cancel": "Cancelar",
       "confirm": "Confirmar"

--- a/src/domain/locales/es/translation.json
+++ b/src/domain/locales/es/translation.json
@@ -212,7 +212,7 @@
     "invalidColdWalletErrorLiquid": "Dirección de billetera Liquid inválida. Verifique que la dirección sea correcta e intente nuevamente.",
     "invalidColdWalletErrorOnchain": "Dirección de billetera Onchain inválida. Use una dirección Bitcoin válida (bc1... o 1... o 3...).",
     "invalidColdWalletErrorLightning": "Dirección de billetera Lightning inválida. Use solo un LNURL o un correo electrónico Lightning válido.",
-    "invalidLnurl": "LNURL inválido. Verifique la dirección e intente nuevamente.",
+    "invalidLnurl": "LNURL no compatible, use el formato de correo electrónico Lightning.",
     "invalidLnurlResponse": "Respuesta inválida del servidor LNURL.",
     "fixedAmountLnurlNotSupported": "Los LNURL con monto fijo no son compatibles. Use un LNURL que permita montos personalizados.",
     "lightningInvoiceNotSupported": "Las facturas Lightning (bolt11) ya no son compatibles. Use solo LNURL o correo electrónico Lightning.",

--- a/src/domain/locales/pt/translation.json
+++ b/src/domain/locales/pt/translation.json
@@ -211,7 +211,7 @@
     "invalidColdWalletErrorLiquid": "Endereço da carteira Liquid inválido. Verifique se o endereço está correto e tente novamente.",
     "invalidColdWalletErrorOnchain": "Endereço da carteira Onchain inválido. Use um endereço Bitcoin válido (bc1... ou 1... ou 3...).",
     "invalidColdWalletErrorLightning": "Endereço da carteira Lightning inválido. Use apenas um LNURL ou um e-mail Lightning válido.",
-    "invalidLnurl": "LNURL inválido. Verifique o endereço e tente novamente.",
+    "invalidLnurl": "LNURL não suportado, use o formato de email Lightning.",
     "invalidLnurlResponse": "Resposta inválida do servidor LNURL.",
     "fixedAmountLnurlNotSupported": "LNURLs com valor fixo não são suportados. Use um LNURL que permita valores personalizados.",
     "lightningInvoiceNotSupported": "Faturas Lightning (bolt11) não são mais suportadas. Use apenas LNURL ou e-mail Lightning.",

--- a/src/domain/locales/pt/translation.json
+++ b/src/domain/locales/pt/translation.json
@@ -326,6 +326,10 @@
       "expected_amount": "Valor Esperado (BRL)",
       "expected_amount_crypto": "Valor Esperado (Cripto)"
     },
+    "wallet_confirmation": {
+      "title": "Confirmação de Endereço",
+      "checkbox_label": "Eu confirmo que o endereço está correto:"
+    },
     "buttons": {
       "cancel": "Cancelar",
       "confirm": "Confirmar"

--- a/src/view/screens/Checkout/modal/ConfirmInfos.tsx
+++ b/src/view/screens/Checkout/modal/ConfirmInfos.tsx
@@ -15,15 +15,20 @@ const Button = ({
   onClick,
   children,
   variant,
+  disabled = false,
 }: {
   onClick: () => void;
   children: React.ReactNode;
   variant?: string;
+  disabled?: boolean;
 }) => (
   <button
     onClick={onClick}
+    disabled={disabled}
     className={`px-6 py-3 rounded-3xl font-bold text-sm sm:text-base transition duration-300 ${
-      variant === 'outline'
+      disabled
+        ? 'bg-gray-500 text-gray-300 cursor-not-allowed'
+        : variant === 'outline'
         ? 'border-2 border-[#F39200] text-[#F39200] hover:bg-[#F39200] hover:text-white'
         : 'bg-[#F39200] text-white hover:bg-orange-600'
     }`}
@@ -93,6 +98,7 @@ export default function ConfirmInfosModal({
 
   const [isDataVisible, setIsDataVisible] = useState(false);
   const [isTaxVisible, setIsTaxVisible] = useState(false);
+  const [isWalletConfirmed, setIsWalletConfirmed] = useState(false);
 
   if (!isOpen) return null;
 
@@ -278,12 +284,28 @@ export default function ConfirmInfosModal({
             </p>
           </div>
 
+          {/* Confirmação de Endereço */}
+          <div className="bg-[#1a1d2b] p-4 rounded-lg border-l-4 border-[#F39200]">
+            <div className="flex items-start space-x-3">
+              <input
+                type="checkbox"
+                id="walletConfirmation"
+                checked={isWalletConfirmed}
+                onChange={(e) => setIsWalletConfirmed(e.target.checked)}
+                className="mt-1 w-5 h-5 text-[#F39200] bg-gray-100 border-gray-300 rounded focus:ring-[#F39200] focus:ring-2"
+              />
+              <label htmlFor="walletConfirmation" className="text-base text-gray-300 cursor-pointer">
+                {t('confirm_infos.wallet_confirmation.checkbox_label')} <br /> <span className="text-[#F39200] break-all">{coldWallet}</span>
+              </label>
+            </div>
+          </div>
+
           {/* Botões */}
           <div className="flex justify-between space-x-4 mt-6">
             <Button variant="outline" onClick={onClose}>
               {t('confirm_infos.buttons.cancel')}
             </Button>
-            <Button onClick={onConfirm}>
+            <Button onClick={onConfirm} disabled={!isWalletConfirmed}>
               {t('confirm_infos.buttons.confirm')}
             </Button>
           </div>


### PR DESCRIPTION
Adiciona um toggle para confirmar se o endereço está correto, irá fazer o usuário pensar duas vezes antes de prosseguir.

A verificação da existência de um endereço Lightning (para ver se o usuário não digitou um endereço errado) ainda não foi feita por causa de erro de CORS (no well-known), estou vendo uma alternativa.

<img width="494" height="188" alt="image" src="https://github.com/user-attachments/assets/44d17490-678c-4b23-bd11-e758b4deedf7" />
